### PR TITLE
Add descriptions to blog collection layouts

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -26,6 +26,7 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
+            <p>{{ post.description | markdownify }}</p>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/_layouts/tag_archive.html
+++ b/_layouts/tag_archive.html
@@ -18,6 +18,7 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
+            <p>{{ post.description | markdownify }}</p>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@ hero: intro
                 {{ post.title | escape }}
             </a>
         </h3>
+        <p>{{ post.description | markdownify }}</p>
         {% if site.show_excerpts %}
         {{ post.excerpt }}
         {% endif %}


### PR DESCRIPTION
Added post descriptions to all blog collection layouts matching the work layout pattern. Displays descriptions in blog listings, tag archives, category archives, and homepage.