### PR TITLE
Add post descriptions and tags to blog layouts

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -26,6 +26,7 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
+            <p>{{ post.description | markdownify }}</p>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -26,7 +26,12 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
-            <p>{{ post.description | markdownify }}</p>
+            <div class="post-description">{{ post.description | markdownify }}</div>
+            <ul class="post-tags">
+                {% for tag in post.tags %}
+                <li class="tag small"><a href="/blog/tag/{{ tag | slugify }}">{{ tag }}</a></li>
+                {% endfor %}
+            </ul>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/_layouts/category_archive.html
+++ b/_layouts/category_archive.html
@@ -18,7 +18,7 @@ layout: default
                         {{ post.title | escape }}
                     </a>
                 </h3>
-                <p>{{ post.description | markdownify }}</p>
+                <div class="post-description">{{ post.description | markdownify }}</div>
                 <ul class="post-tags">
                     {% for category in post.categories %}
                     <li class="tag small"><a href="/work/category/{{ category | slugify }}">{{ category }}</a></li>

--- a/_layouts/tag_archive.html
+++ b/_layouts/tag_archive.html
@@ -18,6 +18,7 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
+            <p>{{ post.description | markdownify }}</p>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/_layouts/tag_archive.html
+++ b/_layouts/tag_archive.html
@@ -18,7 +18,12 @@ layout: default
                     {{ post.title | escape }}
                 </a>
             </h3>
-            <p>{{ post.description | markdownify }}</p>
+            <div class="post-description">{{ post.description | markdownify }}</div>
+            <ul class="post-tags">
+                {% for tag in post.tags %}
+                <li class="tag small"><a href="/blog/tag/{{ tag | slugify }}">{{ tag }}</a></li>
+                {% endfor %}
+            </ul>
             {% if site.show_excerpts %}
             {{ post.excerpt }}
             {% endif %}

--- a/_layouts/work.html
+++ b/_layouts/work.html
@@ -32,7 +32,7 @@ layout: default
                         {{ post.title | escape }}
                     </a>
                 </h3>
-                <p>{{ post.description | markdownify }}</p>
+                <div class="post-description">{{ post.description | markdownify }}</div>
                 <ul class="post-tags">
                     {% for category in post.categories %}
                     <li class="tag small"><a href="/work/category/{{ category | slugify }}">{{ category }}</a></li>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -268,6 +268,10 @@ html.is-animating .transition-fade {
     margin: 0;
 }
 
+.post-description {
+    max-width: 60ch;
+}
+
 .post-tags {
     list-style: none;
     display: flex;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@ hero: intro
                 {{ post.title | escape }}
             </a>
         </h3>
+        <p>{{ post.description | markdownify }}</p>
         {% if site.show_excerpts %}
         {{ post.excerpt }}
         {% endif %}

--- a/index.html
+++ b/index.html
@@ -15,7 +15,12 @@ hero: intro
                 {{ post.title | escape }}
             </a>
         </h3>
-        <p>{{ post.description | markdownify }}</p>
+        <div class="post-description">{{ post.description | markdownify }}</div>
+        <ul class="post-tags">
+            {% for tag in post.tags %}
+            <li class="tag small"><a href="/blog/tag/{{ tag | slugify }}">{{ tag }}</a></li>
+            {% endfor %}
+        </ul>
         {% if site.show_excerpts %}
         {{ post.excerpt }}
         {% endif %}


### PR DESCRIPTION
Added descriptions and tag links to all blog collection listings. Changed description wrappers from <p> to <div class="post-description"> to properly handle markdownified content. Descriptions are constrained to 60ch for readability.