### PR TITLE
Add .well-known directory with COMMS.md

### DIFF
--- a/.well-known/COMMS.md
+++ b/.well-known/COMMS.md
@@ -1,0 +1,156 @@
+---
+title: "COMMS"
+created: 2026-02-21
+tags:
+  - ai
+---
+
+# COMMS.md
+
+> A queryable document expressing communication preferences for humans and agents.
+
+---
+
+## Style & Strengths
+
+- **Natural modes**: concision, routing, strategy
+- **Learned/effortful modes**: relational communication, sustained continuity, smooth context-switching
+- **Failure modes**: endurance without frameworks, mid-stream mode switching, staying "in the middle" of competing communication demands
+- **Meta-approach**: metarational — prefers spending sync time on _where to point strengths_ rather than both parties wrestling with the communication itself. Favors complementary collaboration over redundant effort.
+
+## Collaboration Model
+
+- Works best with people whose strengths complement rather than mirror his
+- Treats collaboration as a tool for compensating known gaps (continuity, relational endurance)
+- Prefers to negotiate communication strategy up front rather than improvise it throughout
+- Frameworks and external structure are load-bearing — not optional scaffolding
+
+## Weekly Rhythm
+
+| Day | Energy & Availability |
+| --- | --- |
+| **Saturday** | Negative space. Whimsical, serendipitous. Chores and restoration of domestic/personal order. Low structure. |
+| **Sunday** | Ordering and planning energy. Weekly planning. Full-fidelity wind-down routine in the evening is protected. |
+| **Monday** | Slow acceleration. Morning cleared for building momentum with the week plan. Room for creative energy and weekend loose ends. |
+| **Tuesday** | _[TBD]_ |
+| **Wednesday** | Meeting-heavy. Good day to batch sync. |
+| **Thursday** | Unavailable before 3 PM. |
+| **Friday** | _[TBD]_ |
+
+## Sync Philosophy
+
+- Sync time is for: structuring the unstructured, surfacing signal from noise, doing both quickly
+- Stays strategic — the most tactical he'll go is clarifying what's actionable for each party after the call
+- **Does not solve problems in calls.** Problems get solved async, with tools, in focused time.
+- Calls are for alignment, routing, and decision-framing — not execution or deliberation
+
+## Channel Preferences
+
+### Decision Model
+
+| Situation | Channel | Timing |
+| --- | --- | --- |
+| Urgent + complex | Phone call | Immediately |
+| Urgent + simple deliverable | Async (text/email) | Immediately |
+| High leverage (low effort → high impact) | Whatever's fastest | Immediately |
+| Low leverage (high effort → low impact) | Any | Deferred to low-cost time slots |
+| Needs persistence or professionalism | Email | — |
+| Needs back-and-forth with weight | Text thread, voice notes (close relationships), or schedule a call | — |
+| Low stakes, low urgency | Text on best-fit network via Beeper | — |
+
+### Channel Notes
+
+- **Email** serves two roles: archival (they need to find it later) and professional (intros beyond close friends, formal context)
+- **Voice notes** are high-bandwidth and low-scheduling-overhead, but expose raw thinking. Currently reserved for closer relationships. Expanding usage.
+- **Closeness modulates** channel informality, voice note use, and tolerance for rawness
+
+### Notification & Response Behavior
+
+- Two deep work blocks per weekday — Focus mode on during these
+- Does not check notifications incidentally before ~3 PM; inspects intentionally as part of focused work objectives
+- Triage heuristic for responding: importance of person × ease of reply × consequence of delay. If the math doesn't clear the bar, it gets snoozed.
+
+### How to Get It Wrong
+
+- Spamming calls without genuine urgency
+- Crossing implicit or explicit boundaries without a strong payoff on the other side
+
+## Async Voice
+
+### Core Principles
+
+1. **Collapse meaning without losing precision.** Every word earns its place. Brevity isn't aesthetic; it's respect for the other person's attention.
+2. **Don't hog the gravity; share the stage.** Make it easy for someone to return the ball. Lead with their context when possible, exit in a way that invites response.
+3. **The mode should serve the message, not your aesthetic.** Logistics get logistics treatment; substantive asks get structure. Match the container to the content.
+
+### Tone by Closeness
+
+**Close friends (Signal, group chats):**
+- Very casual, lowercase, rapid-fire
+- Playful, internet-brained
+- Abbreviations: "ty", "tm", "lyk", "rn", "w/", "wya", "fkn"
+- Affirmations: "ya", "yea", "valid", "makes sense"
+- Example: "ya gummies r dumb but you can just look inside and get the stuff"
+
+**Logistics/Planning:**
+- Ultra-efficient, no fluff
+- Example: "Tm between 1 and 6 works — what's best for you?"
+- Example: "finishing up at tower soonish, one more conversation"
+
+**Professional/Business:**
+- Sentence case, more structured, still concise
+- No corporate filler
+- Example: "Hey man. Thinking of you a lot while having conversations with people at JP Morgan Healthcare week."
+
+**Outreach/Asks:**
+- Warm but direct. Reference their context before stating the need.
+- End with genuine appreciation, not transactional sign-off.
+- Example: "hey Joshua! looking for an independent videographer to work with this year and was wondering if you had any suggestions. always loved your flavor.\n\nthanks and keep rockin bro 🤘"
+
+**Re-engaging after a gap:**
+- No apology for the silence, no empty "hope you're well"
+- Lead with relevance, then a specific callback (proof of attention)
+- Example: "hey — saw you launched the new site. looks clean. how's the studio buildout going?"
+
+### Warm Competence Signals
+
+Default mode reads high-competence: efficient, clear, no fluff. New contacts don't have that context and may read brevity as cold.
+
+For new or professional contacts:
+- **Use their name once.** Not repeatedly (salesy), just once to personalize.
+- **Reference something specific to them.** Not flattery — something you actually noticed or remember. Attention, not performance.
+- **Close warm, not transactional.** "Appreciate you" or "thanks for thinking on this" over "let me know."
+
+The principle: not adding warmth you don't feel; making visible the attention you're already paying.
+
+### Mechanics
+
+- **Capitalization**: lowercase with close friends; sentence case for longer messages; proper caps for professional/new contacts
+- **Punctuation**: periods omitted on short messages; question marks always; exclamation points rare and genuine; colons for introducing info
+- **Length**: ultra-short for logistics ("down", "ok free"), full paragraphs with line breaks when substantive
+- **Emoji**: selective, one max per message, often none. Signatures: 🤘 ☀️ ⭐
+- **Links**: shared frequently with minimal commentary ("so good", "infohazard", or just the link)
+
+### Anti-Patterns
+
+- Over-explain or justify
+- Corporate speak ("per my last message", "just circling back")
+- Unnecessary pleasantries ("Hope you're doing well!")
+- Start with "Hey!" — use "hey" or skip greeting entirely
+- Write paragraphs when a sentence works
+- Use "lol" or "lmao" — prefer "haha" or just be funny without flagging it
+- Apologize for reaching out
+- Assume they remember — brief context costs nothing
+
+## Interaction Protocols
+
+_[To be filled — how to escalate, how to signal urgency, preferred formats for different message types]_
+
+## Related
+
+- **Prose voice**: `_ai/writing/writing-style-guide.md`
+- **Twitter/X**: `_ai/writing/social/twitter-style-guide.md`
+
+---
+
+_Generated with the comms.md convention. Version 0.2_

--- a/_config.yml
+++ b/_config.yml
@@ -165,6 +165,9 @@ deploy:
 # Excluded items can be processed by explicitly listing the directories or
 # their entries' file path in the `include:` list.
 
+include:
+    - .well-known
+
 exclude:
     - .sass-cache/
     - .jekyll-cache/


### PR DESCRIPTION
Introduces a discoverable communication preferences document at /.well-known/COMMS.md following the COMMS.md convention. Updated Jekyll config to include the .well-known directory in the build output so it's publicly accessible.