### PR TITLE
Configure COMMS.md to serve as raw Markdown

### DIFF
--- a/.well-known/COMMS.md
+++ b/.well-known/COMMS.md
@@ -3,6 +3,8 @@ title: "COMMS"
 created: 2026-02-21
 tags:
   - ai
+layout: null
+permalink: /.well-known/COMMS.md
 ---
 
 # COMMS.md

--- a/docs/.well-known/COMMS.md
+++ b/docs/.well-known/COMMS.md
@@ -1,0 +1,249 @@
+<h1 id="commsmd">COMMS.md</h1>
+
+<blockquote>
+  <p>A queryable document expressing communication preferences for humans and agents.</p>
+</blockquote>
+
+<hr />
+
+<h2 id="style--strengths">Style &amp; Strengths</h2>
+
+<ul>
+  <li><strong>Natural modes</strong>: concision, routing, strategy</li>
+  <li><strong>Learned/effortful modes</strong>: relational communication, sustained continuity, smooth context-switching</li>
+  <li><strong>Failure modes</strong>: endurance without frameworks, mid-stream mode switching, staying “in the middle” of competing communication demands</li>
+  <li><strong>Meta-approach</strong>: metarational — prefers spending sync time on <em>where to point strengths</em> rather than both parties wrestling with the communication itself. Favors complementary collaboration over redundant effort.</li>
+</ul>
+
+<h2 id="collaboration-model">Collaboration Model</h2>
+
+<ul>
+  <li>Works best with people whose strengths complement rather than mirror his</li>
+  <li>Treats collaboration as a tool for compensating known gaps (continuity, relational endurance)</li>
+  <li>Prefers to negotiate communication strategy up front rather than improvise it throughout</li>
+  <li>Frameworks and external structure are load-bearing — not optional scaffolding</li>
+</ul>
+
+<h2 id="weekly-rhythm">Weekly Rhythm</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Day</th>
+      <th>Energy &amp; Availability</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Saturday</strong></td>
+      <td>Negative space. Whimsical, serendipitous. Chores and restoration of domestic/personal order. Low structure.</td>
+    </tr>
+    <tr>
+      <td><strong>Sunday</strong></td>
+      <td>Ordering and planning energy. Weekly planning. Full-fidelity wind-down routine in the evening is protected.</td>
+    </tr>
+    <tr>
+      <td><strong>Monday</strong></td>
+      <td>Slow acceleration. Morning cleared for building momentum with the week plan. Room for creative energy and weekend loose ends.</td>
+    </tr>
+    <tr>
+      <td><strong>Tuesday</strong></td>
+      <td><em>[TBD]</em></td>
+    </tr>
+    <tr>
+      <td><strong>Wednesday</strong></td>
+      <td>Meeting-heavy. Good day to batch sync.</td>
+    </tr>
+    <tr>
+      <td><strong>Thursday</strong></td>
+      <td>Unavailable before 3 PM.</td>
+    </tr>
+    <tr>
+      <td><strong>Friday</strong></td>
+      <td><em>[TBD]</em></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="sync-philosophy">Sync Philosophy</h2>
+
+<ul>
+  <li>Sync time is for: structuring the unstructured, surfacing signal from noise, doing both quickly</li>
+  <li>Stays strategic — the most tactical he’ll go is clarifying what’s actionable for each party after the call</li>
+  <li><strong>Does not solve problems in calls.</strong> Problems get solved async, with tools, in focused time.</li>
+  <li>Calls are for alignment, routing, and decision-framing — not execution or deliberation</li>
+</ul>
+
+<h2 id="channel-preferences">Channel Preferences</h2>
+
+<h3 id="decision-model">Decision Model</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Situation</th>
+      <th>Channel</th>
+      <th>Timing</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Urgent + complex</td>
+      <td>Phone call</td>
+      <td>Immediately</td>
+    </tr>
+    <tr>
+      <td>Urgent + simple deliverable</td>
+      <td>Async (text/email)</td>
+      <td>Immediately</td>
+    </tr>
+    <tr>
+      <td>High leverage (low effort → high impact)</td>
+      <td>Whatever’s fastest</td>
+      <td>Immediately</td>
+    </tr>
+    <tr>
+      <td>Low leverage (high effort → low impact)</td>
+      <td>Any</td>
+      <td>Deferred to low-cost time slots</td>
+    </tr>
+    <tr>
+      <td>Needs persistence or professionalism</td>
+      <td>Email</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>Needs back-and-forth with weight</td>
+      <td>Text thread, voice notes (close relationships), or schedule a call</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>Low stakes, low urgency</td>
+      <td>Text on best-fit network via Beeper</td>
+      <td>—</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="channel-notes">Channel Notes</h3>
+
+<ul>
+  <li><strong>Email</strong> serves two roles: archival (they need to find it later) and professional (intros beyond close friends, formal context)</li>
+  <li><strong>Voice notes</strong> are high-bandwidth and low-scheduling-overhead, but expose raw thinking. Currently reserved for closer relationships. Expanding usage.</li>
+  <li><strong>Closeness modulates</strong> channel informality, voice note use, and tolerance for rawness</li>
+</ul>
+
+<h3 id="notification--response-behavior">Notification &amp; Response Behavior</h3>
+
+<ul>
+  <li>Two deep work blocks per weekday — Focus mode on during these</li>
+  <li>Does not check notifications incidentally before ~3 PM; inspects intentionally as part of focused work objectives</li>
+  <li>Triage heuristic for responding: importance of person × ease of reply × consequence of delay. If the math doesn’t clear the bar, it gets snoozed.</li>
+</ul>
+
+<h3 id="how-to-get-it-wrong">How to Get It Wrong</h3>
+
+<ul>
+  <li>Spamming calls without genuine urgency</li>
+  <li>Crossing implicit or explicit boundaries without a strong payoff on the other side</li>
+</ul>
+
+<h2 id="async-voice">Async Voice</h2>
+
+<h3 id="core-principles">Core Principles</h3>
+
+<ol>
+  <li><strong>Collapse meaning without losing precision.</strong> Every word earns its place. Brevity isn’t aesthetic; it’s respect for the other person’s attention.</li>
+  <li><strong>Don’t hog the gravity; share the stage.</strong> Make it easy for someone to return the ball. Lead with their context when possible, exit in a way that invites response.</li>
+  <li><strong>The mode should serve the message, not your aesthetic.</strong> Logistics get logistics treatment; substantive asks get structure. Match the container to the content.</li>
+</ol>
+
+<h3 id="tone-by-closeness">Tone by Closeness</h3>
+
+<p><strong>Close friends (Signal, group chats):</strong></p>
+<ul>
+  <li>Very casual, lowercase, rapid-fire</li>
+  <li>Playful, internet-brained</li>
+  <li>Abbreviations: “ty”, “tm”, “lyk”, “rn”, “w/”, “wya”, “fkn”</li>
+  <li>Affirmations: “ya”, “yea”, “valid”, “makes sense”</li>
+  <li>Example: “ya gummies r dumb but you can just look inside and get the stuff”</li>
+</ul>
+
+<p><strong>Logistics/Planning:</strong></p>
+<ul>
+  <li>Ultra-efficient, no fluff</li>
+  <li>Example: “Tm between 1 and 6 works — what’s best for you?”</li>
+  <li>Example: “finishing up at tower soonish, one more conversation”</li>
+</ul>
+
+<p><strong>Professional/Business:</strong></p>
+<ul>
+  <li>Sentence case, more structured, still concise</li>
+  <li>No corporate filler</li>
+  <li>Example: “Hey man. Thinking of you a lot while having conversations with people at JP Morgan Healthcare week.”</li>
+</ul>
+
+<p><strong>Outreach/Asks:</strong></p>
+<ul>
+  <li>Warm but direct. Reference their context before stating the need.</li>
+  <li>End with genuine appreciation, not transactional sign-off.</li>
+  <li>Example: “hey Joshua! looking for an independent videographer to work with this year and was wondering if you had any suggestions. always loved your flavor.\n\nthanks and keep rockin bro 🤘”</li>
+</ul>
+
+<p><strong>Re-engaging after a gap:</strong></p>
+<ul>
+  <li>No apology for the silence, no empty “hope you’re well”</li>
+  <li>Lead with relevance, then a specific callback (proof of attention)</li>
+  <li>Example: “hey — saw you launched the new site. looks clean. how’s the studio buildout going?”</li>
+</ul>
+
+<h3 id="warm-competence-signals">Warm Competence Signals</h3>
+
+<p>Default mode reads high-competence: efficient, clear, no fluff. New contacts don’t have that context and may read brevity as cold.</p>
+
+<p>For new or professional contacts:</p>
+<ul>
+  <li><strong>Use their name once.</strong> Not repeatedly (salesy), just once to personalize.</li>
+  <li><strong>Reference something specific to them.</strong> Not flattery — something you actually noticed or remember. Attention, not performance.</li>
+  <li><strong>Close warm, not transactional.</strong> “Appreciate you” or “thanks for thinking on this” over “let me know.”</li>
+</ul>
+
+<p>The principle: not adding warmth you don’t feel; making visible the attention you’re already paying.</p>
+
+<h3 id="mechanics">Mechanics</h3>
+
+<ul>
+  <li><strong>Capitalization</strong>: lowercase with close friends; sentence case for longer messages; proper caps for professional/new contacts</li>
+  <li><strong>Punctuation</strong>: periods omitted on short messages; question marks always; exclamation points rare and genuine; colons for introducing info</li>
+  <li><strong>Length</strong>: ultra-short for logistics (“down”, “ok free”), full paragraphs with line breaks when substantive</li>
+  <li><strong>Emoji</strong>: selective, one max per message, often none. Signatures: 🤘 ☀️ ⭐</li>
+  <li><strong>Links</strong>: shared frequently with minimal commentary (“so good”, “infohazard”, or just the link)</li>
+</ul>
+
+<h3 id="anti-patterns">Anti-Patterns</h3>
+
+<ul>
+  <li>Over-explain or justify</li>
+  <li>Corporate speak (“per my last message”, “just circling back”)</li>
+  <li>Unnecessary pleasantries (“Hope you’re doing well!”)</li>
+  <li>Start with “Hey!” — use “hey” or skip greeting entirely</li>
+  <li>Write paragraphs when a sentence works</li>
+  <li>Use “lol” or “lmao” — prefer “haha” or just be funny without flagging it</li>
+  <li>Apologize for reaching out</li>
+  <li>Assume they remember — brief context costs nothing</li>
+</ul>
+
+<h2 id="interaction-protocols">Interaction Protocols</h2>
+
+<p><em>[To be filled — how to escalate, how to signal urgency, preferred formats for different message types]</em></p>
+
+<h2 id="related">Related</h2>
+
+<ul>
+  <li><strong>Prose voice</strong>: <code class="language-plaintext highlighter-rouge">_ai/writing/writing-style-guide.md</code></li>
+  <li><strong>Twitter/X</strong>: <code class="language-plaintext highlighter-rouge">_ai/writing/social/twitter-style-guide.md</code></li>
+</ul>
+
+<hr />
+
+<p><em>Generated with the comms.md convention. Version 0.2</em></p>


### PR DESCRIPTION
Added layout: null and explicit permalink to prevent Jekyll from converting COMMS.md to HTML, ensuring it's served as plain Markdown for easy parsing by agents. Also includes the built output in docs/.well-known/.