### PR TITLE
Add "Venture Capitalist Tries Eat Blueprint" video to Eat Blueprint page

### DIFF
--- a/_projects/2024-01-24-eat-blueprint.md
+++ b/_projects/2024-01-24-eat-blueprint.md
@@ -47,6 +47,11 @@ During my time at Eat Blueprint, I developed menu products to align nutrition pr
 </figure>
 
 <figure>
+    {% youtube "https://www.youtube.com/watch?v=JD5dJGODAfs" %}
+    <figcaption>Venture Capitalist Tries Eat Blueprint</figcaption>
+</figure>
+
+<figure>
     <div class="grid col2">
         <a data-fslightbox="social" data-href="/assets/img/2024-01-24-eat-blueprint-jeff.webp"><img src="/assets/img/2024-01-24-eat-blueprint-jeff.webp" alt="Jeff's Eat Blueprint results" /></a>
         <a data-fslightbox="social" data-href="/assets/img/2024-01-24-eat-blueprint-thomas.webp"><img src="/assets/img/2024-01-24-eat-blueprint-thomas.webp" alt="Thomas's Eat Blueprint results" /></a>

--- a/docs/work/eat-blueprint.html
+++ b/docs/work/eat-blueprint.html
@@ -200,6 +200,13 @@
 </figure>
 
 <figure>
+    <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style>
+<div class="embed-container">    <iframe title="YouTube video player" width="640" height="390" src="//www.youtube.com/embed/JD5dJGODAfs" frameborder="0" allowfullscreen="" loading="lazy"></iframe>
+</div>
+    <figcaption>Venture Capitalist Tries Eat Blueprint</figcaption>
+</figure>
+
+<figure>
     <div class="grid col2">
         <a data-fslightbox="social" data-href="/assets/img/2024-01-24-eat-blueprint-jeff.webp"><img src="/assets/img/2024-01-24-eat-blueprint-jeff.webp" alt="Jeff's Eat Blueprint results" loading="lazy"></a>
         <a data-fslightbox="social" data-href="/assets/img/2024-01-24-eat-blueprint-thomas.webp"><img src="/assets/img/2024-01-24-eat-blueprint-thomas.webp" alt="Thomas's Eat Blueprint results" loading="lazy"></a>


### PR DESCRIPTION
## What

Embeds the YouTube video [_Venture Capitalist Tries Eat Blueprint_](https://www.youtube.com/watch?v=JD5dJGODAfs) on the [Eat Blueprint](https://stedmanhalliday.com/work/eat-blueprint) work page, directly **beneath the Don't Die event flyers** figure.

## How

- Uses the existing **`jekyll-youtube`** plugin (`{% youtube "..." %}`), which emits a responsive 16:9 `.embed-container` iframe.
- Wrapped in a `<figure>` with a `<figcaption>` reading **"Venture Capitalist Tries Eat Blueprint"**, matching the page's other media figures.

## Notes

- `docs/work/eat-blueprint.html` rebuilt with `JEKYLL_ENV=production` (preserves analytics/SEO tags). Incidental build-timestamp churn in other `docs/` files was reverted to keep the diff surgical.
- CI html-proofer runs `Links,Scripts` checks only; the iframe `src` is not validated, so no CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)